### PR TITLE
Add tests more macro tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.6",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -28,6 +43,15 @@ name = "anstyle-parse"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -67,7 +91,7 @@ version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
- "anstream",
+ "anstream 0.6.18",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -127,11 +151,11 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libtest-mimic"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap",
  "escape8259",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 
 [dependencies]
 ctor = "0.2.9"
-libtest-mimic = "0.8.1"
+libtest-mimic = "0.8.2"
 libtest-mimic-collect-macro = "0.3.0"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ mod my_mod1;
 mod my_mod2;
 // ...
 
-#[macro_use]
-extern crate libtest_mimic_collect;
+use libtest_mimic_collect::{test, libtest_mimic::{Completion, Failed}};
 
 #[test]
 fn test_success() {
@@ -48,6 +47,21 @@ fn test_failure() -> Result<(), String> {
 #[test]
 fn test_assert() {
   assert_eq!(1, 2);
+}
+
+#[test]
+fn ignorable_test() -> Result<Completion, Failed> {
+  Ok(Completion::Ignored { reason: Some("Please don't run this test") })
+}
+
+#[test]
+fn explicit_failing_test() -> Result<Completion, Failed> {
+  Ok(Completion::Failed { reason: Some("This test fails explicitly") })
+}
+
+#[test]
+fn explicit_success_test() -> Result<Completion, Failed> {
+  Ok(Completion::Completed)
 }
 
 pub fn main() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,19 +1,98 @@
-use libtest_mimic_collect::TestCollection;
+use std::collections::HashSet;
+
+use libtest_mimic_collect::{TestCollection, libtest_mimic};
 use libtest_mimic_collect::test;
 
+#[derive(Debug)]
+pub struct Failing;
+
+impl From<Failing> for libtest_mimic::Failed {
+    fn from(value: Failing) -> Self {
+        libtest_mimic::Failed::from(format!("{value:?}"))
+    }
+}
+
+#[derive(Debug)]
+pub struct Value(bool);
+
+impl From<Value> for libtest_mimic::Completion {
+    fn from(value: Value) -> Self {
+        if value.0 {
+            libtest_mimic::Completion::Completed
+        } else {
+            libtest_mimic::Completion::Ignored { reason: Some("Value was false".into()) }
+        }
+    }
+}
+
 #[test]
-fn test_number_1() {
+fn success1() {
     assert_eq!(1, 1);
 }
 
 #[test]
-fn test_number_2() {
+fn fail1() {
     assert_eq!(1, 2);
+}
+
+#[test]
+fn fail2() -> Result<(), &'static str> {
+    Err("This is a failing test")
+}
+
+#[test]
+fn fail3() -> Result<(), String> {
+    Err("This is a failing test".to_string())
+}
+
+#[test]
+fn fail4() -> Result<(), libtest_mimic::Failed> {
+    Err("This is a failing test".into())
+}
+
+#[test]
+fn ignore1() -> Result<libtest_mimic::Completion, libtest_mimic::Failed> {
+    Ok(libtest_mimic::Completion::Ignored { reason: Some("My ignore reason".into()) })
+}
+
+#[test]
+fn success2() -> Result<libtest_mimic::Completion, libtest_mimic::Failed> {
+    Ok(libtest_mimic::Completion::Completed)
+}
+
+#[test]
+fn success3() -> Result<Value, Failing> {
+    Ok(Value(true))
+}
+
+#[test]
+fn ignore2() -> Result<Value, Failing> {
+    Ok(Value(false))
+}
+
+#[test]
+fn fail5() -> Result<Value, Failing> {
+    Err(Failing)
 }
 
 pub fn main() {
     let tests = TestCollection::collect_tests();
 
-    assert_eq!(tests[0].name(), "test_number_1");
-    assert_eq!(tests[1].name(), "test_number_2");
+    const EXPECTED_NAMES: [&str; 10] = [
+        "fail1", "fail2", "fail3", "fail4", "fail5", "ignore1", "ignore2", "success1", "success2", "success3"
+    ];
+    let expected: HashSet<_> = EXPECTED_NAMES.into_iter().collect();
+    let actual: HashSet<_> = tests.iter().map(libtest_mimic::Trial::name).collect();
+    assert_eq!(actual, expected);
+
+    let args = libtest_mimic::Arguments { test: true, quiet: true, ..Default::default() };
+
+    // This does print a bunch of confusing stuff, but there is nothing that can be done. as we
+    // want to ensure that tests fail when they should, tests are ignored when they should be and
+    // pass when required
+    let result = libtest_mimic::run(&args, tests);
+    assert_eq!(result.num_failed, 5);
+    assert_eq!(result.num_ignored, 2);
+    assert_eq!(result.num_passed, 3);
+    assert_eq!(result.num_measured, 0);
 }


### PR DESCRIPTION
This change adds more macro tests as a follow-up for https://github.com/mdevils/libtest-mimic-collect-macro/pull/1

Follow-up: https://github.com/mdevils/libtest-mimic-collect/issues/4