### PR TITLE
test macro: support #[ignore] and #[cfg_attr(..., ignore)]

### DIFF
--- a/crates/libtest-mimic-collect-macro/src/lib.rs
+++ b/crates/libtest-mimic-collect-macro/src/lib.rs
@@ -1,16 +1,21 @@
+use std::borrow::Borrow;
+
 use proc_macro::TokenStream;
-use proc_macro2::{Ident, Span};
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::{
-    parse_macro_input, spanned::Spanned, AngleBracketedGenericArguments, GenericArgument, ItemFn,
-    LitStr, PathArguments, ReturnType, Type, TypePath, TypeTuple,
+    parse_macro_input, punctuated::Punctuated, spanned::Spanned, AngleBracketedGenericArguments,
+    Attribute, GenericArgument, ItemFn, LitStr, Meta, MetaNameValue, PathArguments, ReturnType,
+    Token, Type, TypePath, TypeTuple,
 };
 
 /// This macro automatically adds tests marked with #[test] to the test collection.
 /// Tests then can be run with libtest_mimic_collect::TestCollection::run().
 #[proc_macro_attribute]
 pub fn test(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let ItemFn { sig, block, .. } = parse_macro_input!(input as ItemFn);
+    let ItemFn {
+        sig, block, attrs, ..
+    } = parse_macro_input!(input as ItemFn);
 
     let ident = &sig.ident;
     let test_name = ident.to_string();
@@ -84,6 +89,14 @@ pub fn test(_args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
+    // If there was an #[ignore] (or #[cfg_attr(...)] which evaluates to #[ignore], then map it to
+    // a Trial::with_ignored_flag() that expresses the same constraint.
+    let trial = match ignore_attrs(&attrs) {
+        Ok(Some(is_ignored)) => quote! { #trial.with_ignored_flag(#is_ignored) },
+        Ok(None) => trial,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
     (quote! {
         #sig #block
 
@@ -93,4 +106,80 @@ pub fn test(_args: TokenStream, input: TokenStream) -> TokenStream {
         }
     })
     .into()
+}
+
+/// Builds the expression passed to `Trial::with_ignored_flag` from the attributes on a test
+/// function, or `None` if the test has no `#[ignore]`-triggering attributes.
+///
+/// The predicate of a `#[cfg_attr(..., ignore)]` cannot be evaluated inside a proc-macro, so it is
+/// mapped to a runtime `cfg!(any(all(...), ...))` check instead. `#[ignore]` is unconditional but
+/// is essentially treated as `#[cfg_attr(all(), ignore)]` to make things simpler.
+fn ignore_attrs(attrs: &[Attribute]) -> syn::Result<Option<TokenStream2>> {
+    let chains = attrs
+        .iter()
+        .map(|attr| ignore_attr_chains(&attr.meta))
+        // collate errors
+        .collect::<syn::Result<Vec<_>>>()?
+        .into_iter()
+        // drop Ok(None)s
+        .flatten()
+        .collect::<Vec<_>>();
+
+    // TODO: Can we unify this with the same chain-collect-filter logic in ignore_attr_chains?
+
+    if chains.is_empty() {
+        // No chains found, emit nothing.
+        return Ok(None);
+    }
+    Ok(Some(quote! { ::core::cfg!(any( #(#chains),* )) }))
+}
+
+/// Recursively walks an attribute's [`Meta`], returning the equivalent set of [`cfg!`][]
+/// predicates that are necessary for this `Meta` to apply an `#[ignore]` attribute.
+///
+/// [`cfg!`]: core::cfg
+fn ignore_attr_chains(meta: impl Borrow<Meta>) -> syn::Result<Option<TokenStream2>> {
+    match meta.borrow() {
+        // #[ignore] or #[ignore = "reason"] (libtest-mimic cannot handle reason strings).
+        Meta::Path(path) | Meta::NameValue(MetaNameValue { path, .. })
+            if path.is_ident("ignore") =>
+        {
+            // cfg!(all()) is always true -- equivalent to #[cfg_attr()].
+            Ok(Some(quote! { all() }))
+        }
+        // #[cfg_attr(..., ..., ignore, ...)]
+        Meta::List(list) if list.path.is_ident("cfg_attr") => {
+            // Split out the cfg_attr predicate and attributes.
+            let (predicate, attrs) = {
+                let mut cfg_attr = list
+                    .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?
+                    .into_iter();
+                (
+                    // cfg_attr requires a predicate (though this error is never hit because the
+                    // compiler rejects such programs before proc-macros get executed).
+                    cfg_attr.next().ok_or_else(|| {
+                        syn::Error::new_spanned(list, "cfg_attr is missing a predicate")
+                    })?,
+                    // Rest of the meta iterator.
+                    cfg_attr,
+                )
+            };
+
+            let chains = attrs
+                .map(ignore_attr_chains)
+                // collate errors
+                .collect::<syn::Result<Vec<_>>>()?
+                .into_iter()
+                // drop Ok(None)s
+                .flatten()
+                .collect::<Vec<_>>();
+
+            if chains.is_empty() {
+                // No chains found, prune this branch.
+                return Ok(None);
+            }
+            Ok(Some(quote! { all( #predicate, any( #(#chains),* ) ) }))
+        }
+        _ => Ok(None),
+    }
 }

--- a/crates/libtest-mimic-collect/tests/test.rs
+++ b/crates/libtest-mimic-collect/tests/test.rs
@@ -111,16 +111,123 @@ fn fail7() -> CustomReturn {
     CustomReturn(false)
 }
 
+#[test]
+#[ignore]
+fn ignore_attr() {
+    panic!("ignored tests must not be run");
+}
+
+#[test]
+#[ignore = "this reason is discarded"]
+fn ignore_attr_reason() {
+    panic!("ignored tests must not be run");
+}
+
+// all() is always true.
+#[test]
+#[cfg_attr(all(), ignore)]
+fn ignore_cfg_attr_true() {
+    panic!("ignored tests must not be run");
+}
+
+// any() is always false.
+#[test]
+#[cfg_attr(any(), ignore)]
+fn run_cfg_attr_false() {}
+
+// all() + all() + ignore ==> ignore
+#[test]
+#[cfg_attr(all(), cfg_attr(all(), ignore))]
+fn ignore_nested_cfg_attr() {
+    panic!("ignored tests must not be run");
+}
+
+// Always-true name-value cfg_attr().
+#[test]
+#[cfg_attr(
+    any(
+        target_pointer_width = "16",
+        target_pointer_width = "32",
+        target_pointer_width = "64"
+    ),
+    ignore
+)]
+fn ignore_cfg_attr_name_value() {
+    panic!("ignored tests must not be run");
+}
+
+// all() | any() ==> ignore
+#[test]
+#[cfg_attr(any(), ignore)]
+#[cfg_attr(all(), ignore)]
+fn ignore_two_cfg_attrs() {
+    panic!("ignored tests must not be run");
+}
+
+// RFC 2539 allows for multiple attributes in #[cfg_attr()].
+#[test]
+#[cfg_attr(all(), must_use, ignore)]
+fn ignore_cfg_attr_multi() {
+    panic!("ignored tests must not be run");
+}
+
+#[test]
+#[cfg_attr(all(), must_use, cfg_attr(all(), ignore))]
+fn ignore_cfg_attr_multi_nested() {
+    panic!("ignored tests must not be run");
+}
+
 pub fn main() {
     let tests = TestCollection::collect_tests();
 
-    const EXPECTED_NAMES: [&str; 14] = [
-        "fail1", "fail2", "fail3", "fail4", "fail5", "fail6", "fail7", "ignore1", "ignore2",
-        "ignore3", "success1", "success2", "success3", "success4",
+    const EXPECTED_NAMES: [&str; 23] = [
+        "fail1",
+        "fail2",
+        "fail3",
+        "fail4",
+        "fail5",
+        "fail6",
+        "fail7",
+        "ignore1",
+        "ignore2",
+        "ignore3",
+        "ignore_attr",
+        "ignore_attr_reason",
+        "ignore_cfg_attr_multi",
+        "ignore_cfg_attr_multi_nested",
+        "ignore_cfg_attr_name_value",
+        "ignore_cfg_attr_true",
+        "ignore_nested_cfg_attr",
+        "ignore_two_cfg_attrs",
+        "run_cfg_attr_false",
+        "success1",
+        "success2",
+        "success3",
+        "success4",
     ];
     let expected: HashSet<_> = EXPECTED_NAMES.into_iter().collect();
     let actual: HashSet<_> = tests.iter().map(libtest_mimic::Trial::name).collect();
     assert_eq!(actual, expected);
+
+    // Verify the compile-time attributes were mapped to the runtime ignored flag correctly.
+    let ignored: HashSet<_> = tests
+        .iter()
+        .filter(|trial| trial.has_ignored_flag())
+        .map(libtest_mimic::Trial::name)
+        .collect();
+    let expected_ignored: HashSet<_> = [
+        "ignore_attr",
+        "ignore_attr_reason",
+        "ignore_cfg_attr_multi",
+        "ignore_cfg_attr_multi_nested",
+        "ignore_cfg_attr_name_value",
+        "ignore_cfg_attr_true",
+        "ignore_nested_cfg_attr",
+        "ignore_two_cfg_attrs",
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(ignored, expected_ignored);
 
     let args = libtest_mimic::Arguments {
         test: true,
@@ -133,7 +240,7 @@ pub fn main() {
     // pass when required
     let result = libtest_mimic::run(&args, tests);
     assert_eq!(result.num_failed, 7);
-    assert_eq!(result.num_ignored, 3);
-    assert_eq!(result.num_passed, 4);
+    assert_eq!(result.num_ignored, 11);
+    assert_eq!(result.num_passed, 5);
     assert_eq!(result.num_measured, 0);
 }


### PR DESCRIPTION
Because `#[cfg_attr(...)]` can be nested this is a little more complicated
than you might expect, but the general idea is to collect all of the
predicate chains that lead to an "ignore" attribute and then combine
them into one `cfg!(...)` invocation to set `Trial::with_ignored_flag`.

Implements #6
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>